### PR TITLE
current_app is removed in django 1.10

### DIFF
--- a/accountsplus/__init__.py
+++ b/accountsplus/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 default_app_config = 'accountsplus.apps.AccountsConfig'
 

--- a/accountsplus/admin.py
+++ b/accountsplus/admin.py
@@ -231,8 +231,7 @@ class BaseUserAdmin(django.contrib.auth.admin.UserAdmin):
         }
         return django.template.response.TemplateResponse(
             request, self.change_user_password_template or
-            'admin/auth/user/change_password.html',
-            context, current_app=self.admin_site.name)
+            'admin/auth/user/change_password.html', context)
 
 
 class BaseCompanyAdmin(django.contrib.admin.ModelAdmin):


### PR DESCRIPTION
As part of django 1.10 release notes, `current_app` parameter is removed from `django.template.response.TemplateResponse`
@danaspiegel @awartani 